### PR TITLE
Jinja Errors Fix

### DIFF
--- a/actions/lib/base_action.py
+++ b/actions/lib/base_action.py
@@ -158,7 +158,8 @@ class BaseAction(Action):
 
         # Jinja syntax errors
         if 'errors' in error_result:
-            return error_result['errors'][0]['message']
+            error = error_result['errors'][0]['message']
+            return error.replace("{{", '').replace("}}", '')
 
         # Bolt plans (https://github.com/StackStorm-Exchange/stackstorm-bolt)
         if ('result' in error_result and

--- a/actions/lib/base_action.py
+++ b/actions/lib/base_action.py
@@ -88,6 +88,7 @@ class BaseAction(Action):
                     err_message = self.format_error_strings(self.get_error_message(error.result))
                 else:
                     err_message = self.get_error_message(error.result)
+                    err_message - err_message.encode('utf-8')
 
                 if "orquesta" in error.context:
                     err_string += self.get_error_string(html_tags,
@@ -114,6 +115,7 @@ class BaseAction(Action):
                     parent_error = self.errors_as_string
                 else:
                     parent_error = self.get_error_message(self.parent_error.result)
+                    parent_error = parent_error.encode('utf-8')
 
                 err_string += self.get_error_string(html_tags,
                                                     self.parent_error

--- a/actions/lib/base_action.py
+++ b/actions/lib/base_action.py
@@ -148,7 +148,7 @@ class BaseAction(Action):
 
         error_string = error_string.replace('\n', '<br>')
 
-        return error_string
+        return error_string.encode('utf-8')
 
     def get_error_message(self, error_result):
         # Custom Error Messages returned from workflow outputs

--- a/actions/lib/base_action.py
+++ b/actions/lib/base_action.py
@@ -51,7 +51,8 @@ class BaseAction(Action):
                 st2_executions = self.st2_client.executions
                 execution = st2_executions.get_by_id(parent_execution)
             if (str(execution.status) == "failed" or str(execution.status) == "timeout"):
-                if "orquesta" in execution.context and execution.context['orquesta']['task_name'] in ignored_error_tasks:
+                if ("orquesta" in execution.context and execution.context['orquesta']['task_name']
+                        in ignored_error_tasks):
                     pass
                 else:
                     execution_result = execution.result
@@ -88,7 +89,7 @@ class BaseAction(Action):
                     err_message = self.format_error_strings(self.get_error_message(error.result))
                 else:
                     err_message = self.get_error_message(error.result)
-                    err_message - err_message.encode('utf-8')
+                    err_message = err_message.encode('utf-8')
 
                 if "orquesta" in error.context:
                     err_string += self.get_error_string(html_tags,

--- a/actions/lib/base_action.py
+++ b/actions/lib/base_action.py
@@ -159,7 +159,7 @@ class BaseAction(Action):
         # Jinja syntax errors
         if 'errors' in error_result:
             error = error_result['errors'][0]['message']
-            return error.replace("{{", '').replace("}}", '')
+            return error.replace("{{", '\{\{').replace("}}", '\}\}')
 
         # Bolt plans (https://github.com/StackStorm-Exchange/stackstorm-bolt)
         if ('result' in error_result and

--- a/tests/test_action_lib_base_action.py
+++ b/tests/test_action_lib_base_action.py
@@ -347,9 +347,10 @@ class TestBaseAction(ErrorsBaseActionTestCase):
 
     def test_get_error_message_jinja(self):
         action = self.get_action_instance({})
-        expected_result = 'test_error'
+        expected_result = "\{\{ test_error \}\}"
+        test_error = "{{ test_error }}"
         test_error_result = {
-            'errors': [{'message': expected_result}]
+            'errors': [{'message': test_error}]
         }
         result = action.get_error_message(test_error_result)
         self.assertEqual(result, expected_result)

--- a/tests/test_action_lib_execution_find_error_results.py
+++ b/tests/test_action_lib_execution_find_error_results.py
@@ -181,6 +181,7 @@ class TestExecutionFindErrorResults(ErrorsBaseActionTestCase):
         mock_execution = mock.Mock(spec=True,
                                    id='test1',
                                    status='failed',
+                                   context='test_context',
                                    action={'name': 'test_action1'},
                                    result={'task_list': test_task_list,
                                            'key1': 'val1',

--- a/tests/test_sensor_cron_sensor.py
+++ b/tests/test_sensor_cron_sensor.py
@@ -105,7 +105,7 @@ class CronSensorTestCase(BaseSensorTestCase):
             'st2_server': 'st2_test',
             'st2_execution_id': '',
             'st2_comments': 'Cron job is not running and no enforcements can be found',
-            'st2_state': 'error'
+            'st2_state': 'open'
         }
 
         sensor.poll()
@@ -134,7 +134,7 @@ class CronSensorTestCase(BaseSensorTestCase):
             'st2_server': 'st2_test',
             'st2_execution_id': '',
             'st2_comments': 'Cron job did not run',
-            'st2_state': 'error'
+            'st2_state': 'open'
         }
 
         result_value = sensor.check_enforcements(**test_dict)


### PR DESCRIPTION
Removing curly braces from Jinja error messages since Jinja will try to evaluate these strings when used in workflows