### PR TITLE
feature/slack-alerts-trigger

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v1.0.2
+
+ * Adds new trigger payload to track previous state
+
+Contributed by Jacob Huff (Encore Technologies)
+
 ## v1.0.1
 
  * Enabling sensor in sensor parameters
@@ -18,7 +24,7 @@ Switches stackstorm-ci url to an ssh url
 
 ## v0.1.1
 
-Fixes the following bugs/issues: 
+Fixes the following bugs/issues:
 	- executions where all tasks succeed but workflow fails were not detected
 	- adds support for generic StackStorm errors like timouts
 	- removes byte conversions to unicode

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,10 +2,10 @@
 ref: errors
 name: errors
 description: Error pack used to generate errors for tasks/workflows
-keywords: 
+keywords:
     - cookiecutter
     - errors
-version: 1.0.1
+version: 1.0.2
 author: Alex Chrystal
 email: code@encore.tech
 python_versions:

--- a/sensors/cron_sensor.yaml
+++ b/sensors/cron_sensor.yaml
@@ -33,3 +33,29 @@
           st2_state:
             type: "string"
             format: "The state that the error event should be in"
+    -
+      name: "error_cron_event_enhanced"
+      description: "Enhanced trigger with previous state tracking for cron job state transitions"
+      payload_schema:
+        type: "object"
+        properties:
+          st2_comments:
+            type: "string"
+            format: "Comments on what is happening with the cron job."
+          st2_execution_id:
+            type: "string"
+            format: "Stackstorm execution id"
+            default: ""
+          st2_rule_name:
+            type: "string"
+            format: "Stackstorm rule name"
+          st2_server:
+            type: "string"
+            format: "Stackstorm server with the Cron error"
+          st2_state:
+            type: "string"
+            format: "The current state that the error event should be in"
+          st2_previous_state:
+            type: "string"
+            format: "The previous state of the cron job for tracking state transitions"
+            default: "unknown"


### PR DESCRIPTION
- Updates CronSensor with additional trigger to track previous state of Cron Jobs
- This allows actions to have awareness of what state the Cron Job is transitioning from
- Maintains functionality of existing trigger instances